### PR TITLE
Update coat of arms URL in emblems.json

### DIFF
--- a/myproject/myapp/static/json/emblems.json
+++ b/myproject/myapp/static/json/emblems.json
@@ -170,7 +170,7 @@
     {
         "country": {
             "name": "Syria",
-            "url": "https://upload.wikimedia.org/wikipedia/commons/8/82/Coat_of_arms_of_Syria.svg",
+            "url": "https://upload.wikimedia.org/wikipedia/commons/a/ae/Coat_of_arms_of_Syria_%282024%E2%80%93present%29_variation_media.svg",
             "license": "Public domain"
         }
     },


### PR DESCRIPTION
Updated coat of arms of Syria (2024–present) variation from Wikimedia.